### PR TITLE
Update requirements.txt for newer Python versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-cherrypy==11.0.0
+cherrypy==18.9.0


### PR DESCRIPTION
I cloned this and attempted to run in 3.11 on an M2 It had an error:

> AttributeError: module 'inspect' has no attribute 'getargspec'. Did you mean: 'getargs'?

Turns out this isn't your code, but comes from cherrypy.

It built and ran after I made this small change.